### PR TITLE
Functionality for removing tracks from playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ bindings in the resulting buffer:
 | Key              | Description                                                         |
 |:-----------------|:--------------------------------------------------------------------|
 | <kbd>a</kbd>     | Adds track to a playlist                                            |
+| <kbd>r</kbd>     | Removes track from current playlist
 | <kbd>l</kbd>     | Loads the next page of results (pagination)                         |
 | <kbd>g</kbd>     | Clears the results and reloads the first page of results            |
 | <kbd>f</kbd>     | Follows the current playlist                                        |

--- a/smudge-api.el
+++ b/smudge-api.el
@@ -420,6 +420,23 @@ Call CALLBACK with results."
      (format "{\"uris\": [ %s ]}" tracks)
      callback)))
 
+(defun smudge-api-playlist-remove-track (user-id playlist-id track-id callback)
+  "Remove TRACK-ID from PLAYLIST-ID.
+Removed by USER-ID. Call CALLBACK with results."
+  (smudge-api-playlist-remove-tracks user-id playlist-id (list track-id) callback))
+
+(defun smudge-api-playlist-remove-tracks (playlist-id track-ids callback)
+  "Remove TRACK-IDs from PLAYLIST-ID for USER-ID.
+Call CALLBACK with results."
+  (let ((tracks (format "%s" (mapconcat
+                              (lambda (x) (format "{\"uri\": %s}" (smudge-api-format-id "track" x)))
+                              track-ids ","))))
+    (smudge-api-call-async
+     "DELETE"
+     (format "/playlists/%s/tracks" (url-hexify-string playlist-id))
+     (format "{\"tracks\": [ %s ]}" tracks)
+     callback)))
+
 (defun smudge-api-playlist-follow (playlist callback)
   "Add the current user as a follower of PLAYLIST.
 Call CALLBACK with results."

--- a/smudge-api.el
+++ b/smudge-api.el
@@ -421,10 +421,10 @@ Call CALLBACK with results."
      (format "{\"uris\": [ %s ]}" tracks)
      callback)))
 
-(defun smudge-api-playlist-remove-track (user-id playlist-id track-id callback)
+(defun smudge-api-playlist-remove-track (playlist-id track-id callback)
   "Remove TRACK-ID from PLAYLIST-ID.
 Removed by USER-ID. Call CALLBACK with results."
-  (smudge-api-playlist-remove-tracks user-id playlist-id (list track-id) callback))
+  (smudge-api-playlist-remove-tracks playlist-id (list track-id) callback))
 
 (defun smudge-api-playlist-remove-tracks (playlist-id track-ids callback)
   "Remove TRACK-IDs from PLAYLIST-ID for USER-ID.

--- a/smudge-track.el
+++ b/smudge-track.el
@@ -23,6 +23,7 @@
     (set-keymap-parent map tabulated-list-mode-map)
     (define-key map (kbd "M-RET") #'smudge-track-select)
     (define-key map (kbd "a")     #'smudge-track-add)
+    (define-key map (kbd "r")     #'smudge-track-remove)
     (define-key map (kbd "l")     #'smudge-track-load-more)
     (define-key map (kbd "g")     #'smudge-track-reload)
     (define-key map (kbd "f")     #'smudge-track-playlist-follow)
@@ -283,6 +284,19 @@ Default to sortin tracks by number when listing the tracks from an album."
            (smudge-api-get-item-uri selected-track)
            (lambda (_)
              (message "Song added.")))))))))
+
+(defun smudge-track-remove ()
+  "Remove the track under the cursor from the selected playlist."
+  (interactive)
+  (if (bound-and-true-p smudge-selected-playlist)
+      (let ((playlist (smudge-api-get-item-id smudge-selected-playlist))
+            (selected-track (tabulated-list-get-id)))
+        (smudge-api-playlist-remove-track
+         playlist
+         (smudge-api-get-item-uri selected-track)
+         (lambda (_)
+           (message "Song removed."))))
+    (message "Cannot remove a track from a playlist from here")))
 
 (provide 'smudge-track)
 ;;; smudge-track.el ends here


### PR DESCRIPTION
Fixes #9 

Allows you to remove tracks from a playlist in the context of a playlist's track listing, much like other features are available specifically in a playlist track listing.