### PR TITLE
Add a transient map for frequent commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ defined in the Emacs manual [Key Binding
 Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html#Key-Binding-Conventions). Previous
 versions of this package used "M-p"
 
+A transient map can be enabled to allow repeating frequent commands (defined in
+`smudge-transient-command-map`) without having to repeat the prefix key for `smudge-command-map`.
+````el
+(setq smudge-player-use-transient-map t)
+````
+
 In order to get the the client ID and client secret, you need to create
 [a Spotify app](https://developer.spotify.com/my-applications), specifying
 <http://localhost:8080/smudge-api-callback> as the redirect URI (or whichever port you have specified via customize).

--- a/smudge-controller.el
+++ b/smudge-controller.el
@@ -99,6 +99,11 @@ The following placeholders are supported:
   :type 'string
   :group 'smudge)
 
+(defcustom smudge-player-use-transient-map nil
+  "Whether a transient map should be activated after commands that are likely to be repeated."
+  :type 'bool
+  :group 'smudge)
+
 (defvar smudge-controller-timer nil)
 
 (defvar smudge-controller-player-status ""
@@ -106,6 +111,19 @@ The following placeholders are supported:
 
 (defvar smudge-controller-player-metadata nil
   "The metadata about the currently playing track.")
+
+(defmacro defun-smudge-transient (&rest body)
+  "Create a transient smudge command from BODY.
+
+A transient command allows you to immediately invoke another command from
+`smudge-transient-command-map'. See `set-transient-map'.
+
+The transient map is enabled if `smudge-player-use-transient-map' is non-nil."
+  (declare (doc-string 3)
+           (indent defun))
+  `(defun ,@body
+     (when smudge-player-use-transient-map
+       (set-transient-map smudge-transient-command-map))))
 
 (defun smudge-controller-apply (suffix &rest args)
   "Simple facility to emulate multimethods.
@@ -201,22 +219,22 @@ This corresponds to the current REPEATING state."
   (interactive)
   (smudge-controller-apply "player-toggle-play"))
 
-(defun smudge-controller-next-track ()
+(defun-smudge-transient smudge-controller-next-track ()
   "Sends a `next track' command to Spotify process."
   (interactive)
   (smudge-controller-apply "player-next-track"))
 
-(defun smudge-controller-previous-track ()
+(defun-smudge-transient smudge-controller-previous-track ()
   "Sends a `previous track' command to Spotify process."
   (interactive)
   (smudge-controller-apply "player-previous-track"))
 
-(defun smudge-controller-volume-up ()
+(defun-smudge-transient smudge-controller-volume-up ()
   "Increase the volume for the active device."
   (interactive)
   (smudge-controller-apply "volume-up"))
 
-(defun smudge-controller-volume-down ()
+(defun-smudge-transient smudge-controller-volume-down ()
   "Increase the volume for the active device."
   (interactive)
   (smudge-controller-apply "volume-down"))

--- a/smudge.el
+++ b/smudge.el
@@ -155,6 +155,15 @@ Prompt for the NAME and whether it should be made PUBLIC."
   "Keymap for Spotify commands after 'smudge-keymap-prefix'.")
 (fset 'smudge-command-map smudge-command-map)
 
+(defvar smudge-transient-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "M-b") #'smudge-controller-previous-track)
+    (define-key map (kbd "M-f") #'smudge-controller-next-track)
+    (define-key map (kbd "M-u") #'smudge-controller-volume-up)
+    (define-key map (kbd "M-d") #'smudge-controller-volume-down)
+    map)
+  "Transient keymap for commands that are likely to be repeated.")
+
 (easy-menu-add-item nil '("Tools")
                     '("Smudge"
                       ["Play/Pause"     smudge-controller-toggle-play    :active global-smudge-remote-mode]


### PR DESCRIPTION
Hi, thanks for this nice package.

I like to invoke `smudge-command-map` with a prefix key, but that means that I need quite a few key presses if I want to skip multiple tracks or change the volume by multiple increments.

I find that a transient keymap solves this pretty well for me. It lets me define frequent commands that I can repeat without needing to repeat the prefix. While the transient map is active any other key will work as normal and deactivate the transient map. This is the same way that `test-scale-adjust` lets you repeat itself without repeating the `C-x` prefix.

I've added a `defcustom` so that this feature can be enabled optionally:

```emacs-lisp
(use-package smudge
  :custom
  (smudge-player-use-transient-map t)
  :bind-keymap
  ("C-c M-s" . smudge-command-map))
```

I thought I'd share this here in case other were interested in having similar functionality.
