### PR TITLE
Add functionality to add songs to the queue

### DIFF
--- a/smudge-api.el
+++ b/smudge-api.el
@@ -596,5 +596,31 @@ Call CALLBACK if provided."
    nil
    callback))
 
+
+(defun smudge-api-queue-add-track (track-id &optional callback)
+  "Add given TRACK-ID to the queue"
+  (smudge-api-call-async
+   "POST"
+   (concat "/me/player/queue?"
+	   (url-build-query-string `((uri ,track-id))
+				   nil t))
+   nil
+   callback)
+)
+(defun smudge-api-queue-add-tracks (track-ids &optional callback)
+  "Add given TRACK-IDs to the queue"
+  ;; Spotify's API doesn't provide a endpoint that would enable us to
+  ;; add multiple tracks to the queue at the same time.
+  ;; Thus we have to synchronously add the tracks
+  ;; one by one to the queue.
+  (if (car track-ids)
+    (smudge-api-queue-add-track (car track-ids)
+		  (lambda (response)
+		    (smudge-api-queue-add-tracks (cdr track-ids)
+						 nil)))
+    (funcall callback)
+  )
+)
+
 (provide 'smudge-api)
 ;;; smudge-api.el ends here

--- a/smudge-track.el
+++ b/smudge-track.el
@@ -27,6 +27,7 @@
     (define-key map (kbd "g")     #'smudge-track-reload)
     (define-key map (kbd "f")     #'smudge-track-playlist-follow)
     (define-key map (kbd "u")     #'smudge-track-playlist-unfollow)
+    (define-key map (kbd "k")     #'smudge-track-add-to-queue)
     map)
   "Local keymap for `smudge-track-search-mode' buffers.")
 
@@ -283,6 +284,19 @@ Default to sortin tracks by number when listing the tracks from an album."
            (smudge-api-get-item-uri selected-track)
            (lambda (_)
              (message "Song added.")))))))))
+
+(defun smudge-track-add-to-queue ()
+  "Add the track under the cursor to the queue."
+  (interactive)
+  (let ((selected-track (tabulated-list-get-id)))
+    (let ((track-id (smudge-api-get-item-uri selected-track)))
+      (smudge-api-queue-add-track
+       track-id
+       (lambda(_)
+	 (message (format "Added \"%s\" to your queue." (smudge-api-get-item-name selected-track)))))
+  ))
+)
+
 
 (provide 'smudge-track)
 ;;; smudge-track.el ends here


### PR DESCRIPTION
This pull-request adds basic functionality to add songs to the current queue, as mentioned in #73.
It implements two new functions, `smudge-api-queue-add-track` and `smudge-api-queue-add-tracks`.
Furthermore, it extends the Track major mode to allow adding songs under the cursor to the queue by using the `k` key.

Note that this pull-request does not implement a view of the user's queue, as I believe this would be unnecessary, as removing tracks or advancing the queue is not possible through the API.
