### PR TITLE
Allow multi-track queueing

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,13 @@ To search for tracks, run <kbd>M-x smudge-track-search</kbd> and type in your
 query. The results will be displayed in a separate buffer with the following
 key bindings:
 
-| Key              | Description                                                      |
-|:-----------------|:-----------------------------------------------------------------|
-| <kbd>a</kbd>     | Adds track to a playlist                                         |
-| <kbd>l</kbd>     | Loads the next page of results (pagination)                      |
-| <kbd>g</kbd>     | Clears the results and reloads the first page of results         |
-| <kbd>k</kbd>     | Adds track to the queue                                          |
-| <kbd>M-RET</kbd> | Plays the track under the cursor in the context of its album [1] |
+| Key              | Description                                                          |
+|:-----------------|:---------------------------------------------------------------------|
+| <kbd>a</kbd>     | Adds track to a playlist                                             |
+| <kbd>l</kbd>     | Loads the next page of results (pagination)                          |
+| <kbd>g</kbd>     | Clears the results and reloads the first page of results             |
+| <kbd>k</kbd>     | Adds track(s) under the cursor (or inside the region) to the queue   |
+| <kbd>M-RET</kbd> | Plays the track under the cursor in the context of its album [1]     |
 
 [1] D-Bus implementation for GNU/Linux do not support passing the context, so
 only the track under the cursor will be played
@@ -320,7 +320,7 @@ bindings in the resulting buffer:
 | <kbd>g</kbd>     | Clears the results and reloads the first page of results            |
 | <kbd>f</kbd>     | Follows the current playlist                                        |
 | <kbd>u</kbd>     | Unfollows the current playlist                                      |
-| <kbd>k</kbd>     | Adds track to the queue                                             |
+| <kbd>k</kbd>     | Adds track(s) under the cursor (or inside the region) to the queue  |
 | <kbd>M-RET</kbd> | Plays the track under the cursor in the context of the playlist [1] |
 
 Both buffers load the `global-smudge-remote-mode` by default.

--- a/smudge-api.el
+++ b/smudge-api.el
@@ -632,11 +632,12 @@ Call CALLBACK if provided."
   ;; Thus we have to synchronously add the tracks
   ;; one by one to the queue.
   (if (car track-ids)
-      (smudge-api-queue-add-track (car track-ids)
-		                  (lambda (_)
-		                    (smudge-api-queue-add-tracks (cdr track-ids)
-						                 nil)))
-    (funcall callback)))
+      (smudge-api-queue-add-track
+        (car track-ids)
+        (lambda (_)
+          (smudge-api-queue-add-tracks (cdr track-ids) callback)))
+      (when callback(funcall callback))
+  ))
 
 (provide 'smudge-api)
 ;;; smudge-api.el ends here

--- a/smudge-api.el
+++ b/smudge-api.el
@@ -636,8 +636,7 @@ Call CALLBACK if provided."
         (car track-ids)
         (lambda (_)
           (smudge-api-queue-add-tracks (cdr track-ids) callback)))
-      (when callback(funcall callback))
-  ))
+      (when callback (funcall callback))))
 
 (provide 'smudge-api)
 ;;; smudge-api.el ends here

--- a/smudge-track.el
+++ b/smudge-track.el
@@ -301,13 +301,13 @@ Default to sortin tracks by number when listing the tracks from an album."
     (message "Cannot remove a track from a playlist from here")))
 
 (defun smudge-track-add-to-queue ()
-  "Add the track under the cursor to the queue."
+  "Add the track(s) under the cursor (or inside the active region) to the queue."
   (interactive)
   ;; Check whether the mark is active and if so, queue all the tracks in the
   ;; region. If not, queue the track under the cursor.
   (if (null mark-active)
    (let ((selected-track (tabulated-list-get-id)))
-	 (setq track-id (smudge-api-get-item-uri selected-track))
+     (setq track-id (smudge-api-get-item-uri selected-track))
      (smudge-api-queue-add-track
        track-id
        (lambda(_)
@@ -321,15 +321,13 @@ Default to sortin tracks by number when listing the tracks from an album."
          (setq selected-track (tabulated-list-get-id))
          (setq track-id (smudge-api-get-item-uri selected-track))
          (setq tracks (cons track-id tracks))
-         (forward-line 1))
-     )
+         (forward-line 1)))
      (smudge-api-queue-add-tracks
        (reverse tracks)
        nil)
-     (message "Added %d tracks to your queue." (length tracks)) ; Send the message here instead of in the callback
-                                                                 ; because the API call has to sequentially add each song which might take some time.
-     ))
-)
+     ;; Send the message here instead of in the callback
+     ;; because the API call has to sequentially add each song which might take some time.
+     (message "Added %d tracks to your queue." (length tracks)))))
 
 
 (provide 'smudge-track)

--- a/smudge-track.el
+++ b/smudge-track.el
@@ -303,12 +303,33 @@ Default to sortin tracks by number when listing the tracks from an album."
 (defun smudge-track-add-to-queue ()
   "Add the track under the cursor to the queue."
   (interactive)
-  (let ((selected-track (tabulated-list-get-id)))
-    (let ((track-id (smudge-api-get-item-uri selected-track)))
-      (smudge-api-queue-add-track
+  ;; Check whether the mark is active and if so, queue all the tracks in the
+  ;; region. If not, queue the track under the cursor.
+  (if (null mark-active)
+   (let ((selected-track (tabulated-list-get-id)))
+	 (setq track-id (smudge-api-get-item-uri selected-track))
+     (smudge-api-queue-add-track
        track-id
        (lambda(_)
-	 (message "Added \"%s\" to your queue." (smudge-api-get-item-name selected-track)))))))
+         (message "Added \"%s\" to your queue." (smudge-api-get-item-name selected-track)))))
+   (let((start (region-beginning))
+         (end (region-end))
+         (tracks '()))
+     (save-excursion
+       (goto-char start)
+       (while (< (point) end)
+         (setq selected-track (tabulated-list-get-id))
+         (setq track-id (smudge-api-get-item-uri selected-track))
+         (setq tracks (cons track-id tracks))
+         (forward-line 1))
+     )
+     (smudge-api-queue-add-tracks
+       (reverse tracks)
+       nil)
+     (message "Added %d tracks to your queue." (length tracks)) ; Send the message here instead of in the callback
+                                                                 ; because the API call has to sequentially add each song which might take some time.
+     ))
+)
 
 
 (provide 'smudge-track)


### PR DESCRIPTION
I recently found myself adding multiple tracks at the same time to the queue, with the current implementation I submitted in #93, this results in manually having to go over every track in the list.

With this PR, I'd like to extend the queue functionality to allow the user to add a selection of tracks inside the active region to the queue.
When no mark is set, it defaults to just adding the track under the cursor to the queue.