### PR TITLE
Liked Songs support

### DIFF
--- a/smudge-api.el
+++ b/smudge-api.el
@@ -82,7 +82,7 @@ This is used to manually refresh the token when it's about to expire.")
 (defconst smudge-api-endpoint     "https://api.spotify.com/v1")
 (defconst smudge-api-oauth2-auth-url  "https://accounts.spotify.com/authorize")
 (defconst smudge-api-oauth2-token-url "https://accounts.spotify.com/api/token")
-(defconst smudge-api-oauth2-scopes    "playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-read-private user-read-playback-state user-modify-playback-state user-read-playback-state user-read-recently-played")
+(defconst smudge-api-oauth2-scopes    "playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-read-private user-read-playback-state user-modify-playback-state user-read-playback-state user-read-recently-played user-library-read user-library-modify")
 (defconst smudge-api-oauth2-callback  (concat "http://localhost:" smudge-oauth2-callback-port smudge-oauth2-callback-endpoint))
 
 (defun smudge-api-httpd-stop ()
@@ -636,6 +636,38 @@ Call CALLBACK if provided."
         (lambda (_)
           (smudge-api-queue-add-tracks (cdr track-ids) callback)))
       (when callback (funcall callback))))
+
+(defun smudge-api-save-tracks-to-my-library (track-ids &optional callback)
+  "Save one or more TRACK-IDS to the user's \"Liked Songs\" library.
+
+Up to 50 tracks can be specified per API call."
+  (smudge-api-call-async
+   "PUT"
+   (concat "/me/tracks?ids=" (string-join track-ids ","))
+   nil
+   callback))
+
+(defun smudge-api-remove-tracks-from-my-library (track-ids &optional callback)
+  "Save one or more TRACK-IDS to the user's \"Liked Songs\" library.
+
+Up to 50 tracks can be specified per API call."
+  (smudge-api-call-async
+   "DELETE"
+   (concat "/me/tracks?ids=" (string-join track-ids ","))
+   nil
+   callback))
+
+(defun smudge-api-get-my-library-tracks (page callback)
+  "Get a list of songs saved in the user's \"Liked Songs\"library."
+  (let ((offset (* smudge-api-search-limit (1- page))))
+    (smudge-api-call-async
+     "GET"
+     (concat "/me/tracks?"
+             (url-build-query-string `((limit ,smudge-api-search-limit)
+                                       (offset ,offset)
+                                       (market from_token))))
+     nil
+     callback)))
 
 (provide 'smudge-api)
 ;;; smudge-api.el ends here

--- a/smudge.el
+++ b/smudge.el
@@ -160,6 +160,8 @@ Prompt for the NAME and whether it should be made PUBLIC."
     (define-key map (kbd "p s") #'smudge-playlist-search)
     (define-key map (kbd "p c") #'smudge-create-playlist)
     (define-key map (kbd "t s") #'smudge-track-search)
+    (define-key map (kbd "t +") #'smudge-save-playing-track-to-library)
+    (define-key map (kbd "t -") #'smudge-remove-playing-track-from-library)
     (define-key map (kbd "d") #'smudge-select-device)
     map)
   "Keymap for Spotify commands after \\='smudge-keymap-prefix\\='.")

--- a/smudge.el
+++ b/smudge.el
@@ -78,6 +78,15 @@
       (smudge-track-recently-played-tracks-update 1))))
 
 ;;;###autoload
+(defun smudge-my-library ()
+  "Display the songs saved in the current user's Liked Songs."
+  (interactive)
+  (let ((buffer (get-buffer-create "*Liked Songs*")))
+    (with-current-buffer buffer
+      (smudge-track-search-mode)
+      (smudge-track-my-library-update 1))))
+
+;;;###autoload
 (defun smudge-my-playlists ()
   "Display the current user's playlists."
   (interactive)


### PR DESCRIPTION
Adds support for adding and removing the currently playing song from the Liked Songs list.

The naming for Liked Songs is a bit confusing. The official Spotify client calls them Liked Songs, but the [API docs](https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks) calls them "songs saved in the 'Your Music' library". Happy to modify this change based on naming suggestions.

It would probably be nice to have the ability to add/remove marked songs from Linked Songs as well. But it seems a bit confusing to have two sets of functions for this. What do you think of introducing something like `smudge-save-track-to-library-dwim`: If `smudge-track-search-mode` is active, it will save the track at point. Otherwise it will save the currently playing track.

Fixes #69.